### PR TITLE
Add a ref to react-select component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * In general follow (https://docs.npmjs.com/getting-started/semantic-versioning) versioning.
 
 ## <next>
+* Add a reference to the react-select component
 
 ## 3.1.0
 * Add FloatingSelectPortal & FloatingSelectPortalCreatable component for rendering select menu into document body

--- a/src/floating-select-portal/floating-select-portal-creatable.jsx
+++ b/src/floating-select-portal/floating-select-portal-creatable.jsx
@@ -18,7 +18,10 @@ export default class FloatingSelectPortalCreatable extends FloatingSelectBase {
         onMenuOpen={this.handleOpenMenu}
         onMenuClose={this.handleCloseMenu}
         styles={styles(this.props.controlHeight, Portal)}
+        ref={(el) => {
+          this.selectRef = el;
+        }}
       />
     );
-  }
+  };
 }

--- a/src/floating-select-portal/floating-select-portal.jsx
+++ b/src/floating-select-portal/floating-select-portal.jsx
@@ -18,7 +18,10 @@ export default class FloatingSelectPortal extends FloatingSelectBase {
         onMenuOpen={this.handleOpenMenu}
         onMenuClose={this.handleCloseMenu}
         styles={styles(this.props.controlHeight, Portal)}
+        ref={(el) => {
+          this.selectRef = el;
+        }}
       />
     );
-  }
+  };
 }

--- a/src/floating-select/floating-select-creatable.component.jsx
+++ b/src/floating-select/floating-select-creatable.component.jsx
@@ -12,6 +12,9 @@ export default class FloatingSelectCreatable extends FloatingSelectBase {
       onMenuOpen={this.handleOpenMenu}
       onMenuClose={this.handleCloseMenu}
       styles={styles(this.props.controlHeight)}
+      ref={(el) => {
+        this.selectRef = el;
+      }}
     />
   );
 }

--- a/src/floating-select/floating-select.component.jsx
+++ b/src/floating-select/floating-select.component.jsx
@@ -4,15 +4,6 @@ import styles from './styles';
 import FloatingSelectBase from './floating-select-base.component';
 
 export default class FloatingSelect extends FloatingSelectBase {
-  constructor() {
-    super();
-    this.selectRef = null;
-  }
-
-  getRef = () => {
-    return this.selectRef;
-  };
-
   render = () => (
     <Select
       {...this.props}

--- a/src/floating-select/floating-select.component.jsx
+++ b/src/floating-select/floating-select.component.jsx
@@ -4,11 +4,23 @@ import styles from './styles';
 import FloatingSelectBase from './floating-select-base.component';
 
 export default class FloatingSelect extends FloatingSelectBase {
+  constructor() {
+    super();
+    this.selectRef = null;
+  }
+
+  getRef = () => {
+    return this.selectRef;
+  };
+
   render = () => (
     <Select
       {...this.props}
       components={this.state.components}
       menuPlacement="auto"
+      ref={(el) => {
+        this.selectRef = el;
+      }}
       onMenuOpen={this.handleOpenMenu}
       onMenuClose={this.handleCloseMenu}
       styles={styles(this.props.controlHeight)}


### PR DESCRIPTION
We need a way to make a reference a to an original react-select component in @opuscapita/react-grid.